### PR TITLE
Add mobile controls and responsive layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -47,6 +47,11 @@
   align-items: flex-start;
 }
 
+#phaser-container {
+  flex: 1;
+  height: 100vh;
+}
+
 .bg-options {
   display: flex;
   flex-direction: column;
@@ -55,4 +60,20 @@
 
 .bg-options button {
   margin-bottom: 8px;
+}
+
+@media (max-width: 600px) {
+  .game-wrapper {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .bg-options {
+    flex-direction: row;
+    margin: 10px 0;
+  }
+
+  .bg-options button {
+    margin: 0 4px;
+  }
 }

--- a/src/Game.jsx
+++ b/src/Game.jsx
@@ -69,7 +69,20 @@ export default function Game() {
 
         // Input
         this.cursors = this.input.keyboard.createCursorKeys();
-        this.keySpace = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        this.keySpace = this.input.keyboard.addKey(
+          Phaser.Input.Keyboard.KeyCodes.SPACE
+        );
+
+        // Touch/Pointer controls for mobile
+        this.input.on('pointermove', (pointer) => {
+          if (this.state !== 'PLAYING') return;
+          this.player.x = Phaser.Math.Clamp(pointer.x, 0, this.scale.width);
+          this.player.y = Phaser.Math.Clamp(pointer.y, 0, this.scale.height);
+        });
+
+        this.input.on('pointerdown', () => {
+          if (this.state === 'PLAYING') this.shootBullet();
+        });
 
         // Enemy Spawn Timer
         this.spawnTimer = this.time.addEvent({
@@ -278,9 +291,13 @@ export default function Game() {
     // Initialize Phaser Game
     gameRef.current = new Phaser.Game({
       type: Phaser.AUTO,
-      width: 800,
-      height: 600,
+      width: window.innerWidth,
+      height: window.innerHeight,
       parent: 'phaser-container',
+      scale: {
+        mode: Phaser.Scale.FIT,
+        autoCenter: Phaser.Scale.CENTER_BOTH,
+      },
       physics: {
         default: 'arcade',
         arcade: {
@@ -291,9 +308,15 @@ export default function Game() {
       scene: MainScene,
     });
 
+    const resize = () => {
+      gameRef.current.scale.resize(window.innerWidth, window.innerHeight);
+    };
+    window.addEventListener('resize', resize);
+
     return () => {
       gameRef.current.destroy(true);
       gameRef.current = null;
+      window.removeEventListener('resize', resize);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- make Phaser game scale to the window
- add touch controls so the player can move and shoot on mobile
- resize game on window changes
- style phaser container and background buttons for mobile responsiveness

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68434a81cc608333b874612536ed2b48