### PR TITLE
Increase coin rewards per wave in zombie game

### DIFF
--- a/src/zombieGame.jsx
+++ b/src/zombieGame.jsx
@@ -258,7 +258,7 @@ export default function CastleDefenders() {
               })
               .filter((z) => {
                 if (z.hp <= 0) {
-                  setCoins((c) => c + (z.type === 'boss' ? 10 : 1));
+                  setCoins((c) => c + wave);
                   return false;
                 }
                 return true;


### PR DESCRIPTION
## Summary
- reward more coins per zombie kill based on current wave

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c83aa13f88333966c1fb5628b037e