### PR TITLE
Implement new zombie game features

### DIFF
--- a/src/zombieGame.jsx
+++ b/src/zombieGame.jsx
@@ -11,10 +11,10 @@ const CASTLE_POS = { x: WIDTH / 2, y: HEIGHT / 2 };
 /** Data tables */
 // Increase unit damage so most zombies fall after roughly three hits
 const towerData = {
-  archer: { range: 120, damage: 10, reload: 60, color: 'green' },
-  cannon: { range: 110, damage: 20, reload: 80, splash: 30, color: 'orange' },
-  fire: { range: 70, damage: 10, reload: 90, burn: true, color: 'red' },
-  sniper: { range: 200, damage: 40, reload: 120, color: 'purple' },
+  archer: { range: TILE * 2, damage: 10, reload: 60, color: 'green' },
+  cannon: { range: TILE * 2, damage: 20, reload: 80, splash: 30, color: 'orange' },
+  fire: { range: TILE * 2, damage: 10, reload: 90, burn: true, color: 'red' },
+  sniper: { range: TILE * 2, damage: 40, reload: 120, color: 'purple' },
 };
 
 const zombieData = {
@@ -29,6 +29,8 @@ function nextId() {
   uid += 1;
   return uid;
 }
+
+const TOWER_HP = 200;
 
 function useGameLoop(callback, speedRef) {
   useEffect(() => {
@@ -69,10 +71,28 @@ export default function CastleDefenders() {
   const [selected, setSelected] = useState(null);
   const [modifier, setModifier] = useState(null); // 'fog','haste',null
   const [repairs, setRepairs] = useState(0);
-  const [powerCost, setPowerCost] = useState(27); // special power cost (30 - 3)
   const [speed, setSpeed] = useState(1);
+  const [powerOptions, setPowerOptions] = useState(null); // array of power objects
+
+  const [freeUnit, setFreeUnit] = useState(false);
+
+  const [rangeBonus, setRangeBonus] = useState(0); // squares
+  const [fireRateBonus, setFireRateBonus] = useState(0); // percent in decimal
+  const [zHealthMod, setZHealthMod] = useState(1);
+  const [zSpeedMod, setZSpeedMod] = useState(1);
   const speedRef = useRef(1);
   speedRef.current = speed;
+
+  const powers = [
+    { name: 'Increase range by 1 square', action: () => setRangeBonus((b) => b + 1) },
+    { name: 'Increase fire rate by 5%', action: () => setFireRateBonus((b) => b + 0.05) },
+    { name: 'Decrease zombies health by 5%', action: () => setZHealthMod((m) => m * 0.95) },
+    { name: 'Add defences to your castle', action: () => setCastleHP((h) => h + 20) },
+    { name: 'Slow down zombies speed by 5%', action: () => setZSpeedMod((m) => m * 0.95) },
+    { name: 'Get a free unit of your choice', action: () => setFreeUnit(true) },
+    { name: 'Get forty coins', action: () => setCoins((c) => c + 40) },
+    { name: 'Increase castle health by 5%', action: () => setCastleHP((h) => Math.round(h * 1.05)) },
+  ];
 
   const spawnRef = useRef({ left: 0, total: 0 });
   const disabledRef = useRef({ id: null, time: 0 });
@@ -99,9 +119,9 @@ export default function CastleDefenders() {
     const type = types[Math.floor(Math.random() * types.length)];
     const base = zombieData[type];
     const mult = 1 + 0.2 * (wave - 1);
-    const hp = base.hp * mult;
+    const hp = base.hp * mult * zHealthMod;
     const damage = base.damage * mult;
-    const speedZ = base.speed * (modifier === 'haste' ? 1.25 : 1);
+    const speedZ = base.speed * (modifier === 'haste' ? 1.25 : 1) * zSpeedMod;
     const edge = Math.floor(Math.random() * 4);
     let x = 0;
     let y = 0;
@@ -158,14 +178,29 @@ export default function CastleDefenders() {
       }
       return;
     }
-    if (coins < 7) return;
-    const data = towerData[selected];
+    if (!freeUnit && coins < 7) return;
     const id = nextId();
     setTowers((ts) => [
       ...ts,
-      { id, type: selected, level: 1, gx, gy, x: gx * TILE + TILE / 2, y: gy * TILE + TILE / 2, cooldown: 0, cost: 7, disabled: 0 },
+      {
+        id,
+        type: selected,
+        level: 1,
+        gx,
+        gy,
+        x: CASTLE_POS.x,
+        y: CASTLE_POS.y,
+        targetX: gx * TILE + TILE / 2,
+        targetY: gy * TILE + TILE / 2,
+        moving: true,
+        cooldown: 0,
+        cost: 7,
+        disabled: 0,
+        hp: TOWER_HP,
+      },
     ]);
-    setCoins((c) => c - 7);
+    if (!freeUnit) setCoins((c) => c - 7);
+    setFreeUnit(false);
   }
 
   function repairCastle() {
@@ -178,24 +213,12 @@ export default function CastleDefenders() {
   }
 
   function useSpecialPower() {
-    if (coins < powerCost) return;
-    setCoins((c) => c - powerCost);
-    const level = Math.floor((powerCost + 3) / 30);
-    setZombies((zs) =>
-      zs
-        .map((z) => {
-          z.hp -= level * 50;
-          return z;
-        })
-        .filter((z) => {
-          if (z.hp <= 0) {
-            setCoins((c) => c + wave);
-            return false;
-          }
-          return true;
-        })
-    );
-    setPowerCost((c) => c + 30);
+    const opts = [];
+    while (opts.length < 4) {
+      const p = powers[Math.floor(Math.random() * powers.length)];
+      if (!opts.includes(p)) opts.push(p);
+    }
+    setPowerOptions(opts);
   }
 
   useGameLoop((delta) => {
@@ -211,6 +234,13 @@ export default function CastleDefenders() {
     setZombies((zs) =>
       zs
         .map((z) => {
+          const targetTower = towers.find((t) => distance(t, z) < 20);
+          if (targetTower) {
+            setTowers((ts) =>
+              ts.map((t) => (t.id === targetTower.id ? { ...t, hp: t.hp - 5 } : t))
+            );
+            return z;
+          }
           const angle = Math.atan2(CASTLE_POS.y - z.y, CASTLE_POS.x - z.x);
           z.x += Math.cos(angle) * z.speed * (delta / 60);
           z.y += Math.sin(angle) * z.speed * (delta / 60);
@@ -224,39 +254,54 @@ export default function CastleDefenders() {
     );
     // update towers
     setTowers((ts) =>
-      ts.map((t) => {
-        if (t.disabled > 0) t.disabled -= delta;
-        if (t.cooldown > 0) t.cooldown -= delta;
-        const rangeMult = modifier === 'fog' ? 0.7 : 1;
-        if (t.cooldown <= 0 && t.disabled <= 0) {
-          const base = towerData[t.type];
-          const r = base.range * rangeMult * (1 + 0.1 * (t.level - 1));
-          const target = zombies.reduce((acc, z) => {
-            const d = distance(z, t);
-            return d <= r && (!acc || d < distance(acc, t)) ? z : acc;
-          }, null);
-          if (target) {
-            const dmg = base.damage * (1 + 0.2 * (t.level - 1));
-            const speedP = 200;
-            const angle = Math.atan2(target.y - t.y, target.x - t.x);
-            const p = {
-              id: nextId(),
-              x: t.x,
-              y: t.y,
-              dx: Math.cos(angle) * speedP,
-              dy: Math.sin(angle) * speedP,
-              damage: dmg,
-              splash: base.splash,
-              burn: t.level >= 5 && base.burn,
-              pierce: t.level >= 5 && t.type === 'sniper',
-            };
-            setProjectiles((ps) => [...ps, p]);
-            t.cooldown = base.reload / (1 + 0.1 * (t.level - 1));
-            console.log('pew');
+      ts
+        .map((t) => {
+          if (t.disabled > 0) t.disabled -= delta;
+          if (t.cooldown > 0) t.cooldown -= delta;
+
+          if (t.moving) {
+            const ang = Math.atan2(t.targetY - t.y, t.targetX - t.x);
+            t.x += Math.cos(ang) * 60 * (delta / 60);
+            t.y += Math.sin(ang) * 60 * (delta / 60);
+            if (distance(t, { x: t.targetX, y: t.targetY }) < 5) {
+              t.x = t.targetX;
+              t.y = t.targetY;
+              t.moving = false;
+            }
           }
-        }
-        return t;
-      })
+
+          const rangeMult = modifier === 'fog' ? 0.7 : 1;
+          const base = towerData[t.type];
+          const r =
+            (base.range + rangeBonus * TILE) * rangeMult * (1 + 0.1 * (t.level - 1));
+          if (t.cooldown <= 0 && t.disabled <= 0 && !t.moving) {
+            const target = zombies.reduce((acc, z) => {
+              const d = distance(z, t);
+              return d <= r && (!acc || d < distance(acc, t)) ? z : acc;
+            }, null);
+            if (target) {
+              const dmg = base.damage * (1 + 0.2 * (t.level - 1));
+              const speedP = 200;
+              const angle = Math.atan2(target.y - t.y, target.x - t.x);
+              const p = {
+                id: nextId(),
+                x: t.x,
+                y: t.y,
+                dx: Math.cos(angle) * speedP,
+                dy: Math.sin(angle) * speedP,
+                damage: dmg,
+                splash: base.splash,
+                burn: t.level >= 5 && base.burn,
+                pierce: t.level >= 5 && t.type === 'sniper',
+              };
+              setProjectiles((ps) => [...ps, p]);
+              t.cooldown =
+                (base.reload / (1 + 0.1 * (t.level - 1))) / (1 + fireRateBonus);
+            }
+          }
+          return t;
+        })
+        .filter((t) => t.hp > 0)
     );
     // update projectiles
     setProjectiles((ps) =>
@@ -344,8 +389,13 @@ export default function CastleDefenders() {
     setProjectiles([]);
     setRepairs(0);
     setModifier(null);
-    setPowerCost(27);
     unlockedRef.current = ['walker'];
+    setRangeBonus(0);
+    setFireRateBonus(0);
+    setZHealthMod(1);
+    setZSpeedMod(1);
+    setFreeUnit(false);
+    setPowerOptions(null);
     setWaveActive(false);
   }
 
@@ -366,7 +416,7 @@ export default function CastleDefenders() {
             </button>
           ))}
           <button onClick={repairCastle} disabled={coins < repairCost || castleHP >= 100}>Repair {repairCost}c</button>
-          <button onClick={useSpecialPower} disabled={coins < powerCost}>Power {powerCost}c</button>
+          <button onClick={useSpecialPower}>Power</button>
         </div>
         <canvas
           ref={canvasRef}
@@ -388,6 +438,15 @@ export default function CastleDefenders() {
         <div style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', background: 'rgba(0,0,0,0.8)', color: '#fff', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
           <h1>Game Over</h1>
           <button onClick={restart}>Restart</button>
+        </div>
+      )}
+      {powerOptions && (
+        <div style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', background: 'rgba(0,0,0,0.7)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+          {powerOptions.map((p) => (
+            <button key={p.name} onClick={() => { p.action(); setPowerOptions(null); }} style={{ margin: 4 }}>
+              {p.name}
+            </button>
+          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- update unit range to two grid squares
- add free power selection system with eight options
- allow placing free units from castle
- make towers move to their tile and track health
- let zombies attack towers and castle

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684c8eff2be88333ad506836720b6666