### PR TITLE
Reset wave after castle falls

### DIFF
--- a/src/zombieGame.jsx
+++ b/src/zombieGame.jsx
@@ -110,6 +110,17 @@ export default function CastleDefenders() {
   const disabledRef = useRef({ id: null, time: 0 });
   const unlockedRef = useRef(['walker']);
 
+  useEffect(() => {
+    if (castleHP <= 0) {
+      setWave(1);
+      setRangeBonus(0);
+      setFireRateBonus(0);
+      setZHealthMod(1);
+      setZSpeedMod(1);
+      unlockedRef.current = ['walker'];
+    }
+  }, [castleHP]);
+
   function startWave() {
     if (waveActive) return;
     setWaveActive(true);
@@ -409,6 +420,7 @@ export default function CastleDefenders() {
   }, speedRef);
 
   function restart() {
+    setWave(1);
     setCoins(20);
     setCastleHP(100);
     setTowers([]);


### PR DESCRIPTION
## Summary
- reset wave to 1 in restart handler
- automatically revert difficulty modifiers and wave when the castle is destroyed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684dd57197408333a8e5997b490a5703